### PR TITLE
Respect promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ let executeHooksWithArgs = (hooks, args) => {
                 commandIsRunning = _commandIsRunning
             }).run()
         } catch (e) {
-            // here could be your error message
+            console.error(e)
         }
 
         resolve()

--- a/index.js
+++ b/index.js
@@ -29,12 +29,15 @@ let executeHooksWithArgs = (hooks, args) => {
     }
 
     hooks = hooks.map((hook) => new Promise((resolve) => {
+        let _commandIsRunning = commandIsRunning
         try {
             /**
              * after command hooks require additional Fiber environment
              */
             return Fiber(() => {
+                commandIsRunning = true
                 resolve(hook.apply(null, args))
+                commandIsRunning = _commandIsRunning
             }).run()
         } catch (e) {
             // here could be your error message

--- a/index.js
+++ b/index.js
@@ -49,6 +49,19 @@ let executeHooksWithArgs = (hooks, args) => {
 }
 
 /**
+ * global function to wrap callbacks into Fiber context
+ * @param  {Function} fn  function to wrap around
+ * @return {Function}     wrapped around function
+ */
+global.wdioSync = function (fn) {
+    return function (...args) {
+        return Fiber(() => {
+            fn.apply(this, args)
+        }).run()
+    }
+}
+
+/**
  * wraps a function into a Fiber ready context to enable sync execution and hooks
  * @param  {Function}   fn             function to be executed
  * @param  {String}     commandName    name of that function

--- a/index.js
+++ b/index.js
@@ -147,9 +147,15 @@ let wrapCommands = function (instance, beforeCommand, afterCommand) {
     }
 }
 
-let runInFiberContext = function (testInterface, ui, before, after, fnName) {
+/**
+ * [runInFiberContext description]
+ * @param  {[type]} testInterfaceFnName  global command that runs specs
+ * @param  {[type]} before               before hook hook
+ * @param  {[type]} after                after hook hook
+ * @param  {[type]} fnName               test interface command to wrap
+ */
+let runInFiberContext = function (testInterfaceFnName, before, after, fnName) {
     let origFn = global[fnName]
-    let testInterfaceFnName = testInterface[ui][2]
 
     let runSpec = function (specTitle, specFn) {
         return origFn(specTitle, function (done) {

--- a/index.js
+++ b/index.js
@@ -160,13 +160,13 @@ let runInFiberContext = function (testInterface, ui, before, after, fnName) {
         })
     }
 
-    let runHook = function (specTitle, specFn) {
-        return origFn(specTitle, function (done) {
+    let runHook = function (hookFn) {
+        return origFn(function (done) {
             Fiber(() => {
-                before()
-                specFn.call(this)
-                after()
-                done()
+                executeHooksWithArgs(before)
+                    .then(() => hookFn.call(this))
+                    .then(() => executeHooksWithArgs(after))
+                    .then(() => done(), () => done())
             }).run()
         })
     }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ import Fiber from 'fibers'
 
 const SYNC_COMMANDS = ['domain', '_events', '_maxListeners', 'setMaxListeners', 'emit',
     'addListener', 'on', 'once', 'removeListener', 'removeAllListeners', 'listeners']
-const NOOP = function () {}
 
 let commandIsRunning = false
 
@@ -196,33 +195,4 @@ let runInFiberContext = function (testInterface, ui, before, after, fnName) {
     }
 }
 
-let runHook = function (hookFn, cb = NOOP) {
-    return new Promise((resolve, reject) => {
-        Fiber(() => {
-            try {
-                hookFn()
-                cb()
-                resolve()
-            } catch (e) {
-                reject(e)
-            }
-        }).run()
-    })
-}
-
-/**
- * wraps a function that returns a promise to be used within Fiber
- * @param  {Function} origFn  actual function to be executed (needs to return a Promise)
- * @return {Object}           Fiber wait object
- */
-let wrapFn = function (origFn) {
-    return function (...commandArgs) {
-        let future = new Future()
-        let result = origFn.apply(this, commandArgs)
-
-        result.then(future.return.bind(future), future.throw.bind(future))
-        return future.wait()
-    }
-}
-
-export { wrapCommand, wrapCommands, runInFiberContext, runHook, wrapFn }
+export { wrapCommand, wrapCommands, runInFiberContext, executeHooksWithArgs }

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ let runInFiberContext = function (testInterface, ui, before, after, fnName) {
             return runSpec(specTitle, specFn)
         }
 
-        return runHook(specTitle, specFn)
+        return runHook(specFn)
     }
 
     if (fnName === testInterfaceFnName) {


### PR DESCRIPTION
@georgecrawford please review

this patch includes:
- new method: `executeHooksWithArgs` which is a helper to execute a list of functions/hooks with certain parameters within a Fiber context. All hooks getting executed respect promise execution and won't let the test process fail if something breaks
- registering a global method called `wdioSync`. Apparently if you execute a browser command in a callback function the Fiber context is gone. This methods helps people to reapply that context, e.g.

```js
before: function() {
    console.log(browser.status()); // works
    process.nextTick(function() {
        console.log(browser.status()); // fails
    })
}
```
Solution:
```js
before: function() {
    console.log(browser.status()); // works
    process.nextTick(wdioSync(function() {
        console.log(browser.status()); // works
    }))
}
```

- execute `future.wait` in a try/catch block due to this problem above. If the Fibers context isn't given we don't just throw an error anymore but execute the actual function without Fibers. This allows us to integrate the promise behaviour within the sync context. Let's say someone is using a different library that supports promises to setup something, the user can either use wdioSync to get the Fibers context back or just stick with the promise:

```js
before: function() {
    browser.url('http://something.com'); // works synchronously
    otherLib().then(function() {
        // no fibers context available anymore, use promise
        return browser.getTitle();
    }).then(title) {
        console.log(title); // still works with promises
    })
}
```
 
- separated `wrapCommands` into `wrapCommands` and `wrapCommand` (which is the only place where we use the Future construct
- got rid of `runHook` (replaced by `executeHooksWithArgs`) and `wrapFn` (got obsolete)

Missing in this PR and WIP: unit tests. Wanted to make sure that PRs get tested accordingly. So I am using the process to fix this too.