### PR TITLE
Sync async 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,14 @@ let wrapCommand = function (fn, commandName, beforeCommand, afterCommand) {
             return future.wait()
         } catch (e) {
             futureFailed = true
+            console.log('futureFailed', e.stack)
+
+            // TODO: if fn() has already thrown an exception, why re-run it here?
             return fn.apply(this, commandArgs)
+            .catch((e) => {
+                console.log('natural fn failed', e.stack)
+                throw e
+            })
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -217,8 +217,7 @@ let wrapCommands = function (instance, beforeCommand, afterCommand) {
          * #functionalProgrammingWTF!
          */
         commandGroup[fnName] = wrapCommand((...args) => new Promise((r) => {
-            fn = wdioSync(fn, r)
-            fn.apply(instance, args)
+            wdioSync(fn, r).apply(instance, args)
         }), fnName, beforeCommand, afterCommand)
     }
 }


### PR DESCRIPTION
Opening this PR just to discuss the problems I've seen so far.

1: if an error is thrown in a custom function, it's run again here: https://github.com/webdriverio/wdio-sync/compare/sync-async-2?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR146, and throws the same error again at the `natural fn failed` line. This is weird from the developer's POV.

2: Before this change (https://github.com/webdriverio/wdio-sync/compare/sync-async-2?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR220) I saw that each time a custom command was run, it was wrapped in another layer of `wdioSync`, so every call after the first one would return `undefined`.

3: It's actually not waiting as I'd expect now. Can you suggest how to fix this:
```js
		browser.addCommand('wait1', function() {
			this.pause(1000);
			console.log('wait1 complete', Date.now() - start);
		});

		browser.addCommand('wait2', function async() {
			return new Promise((resolve) => {
				setTimeout(() => {
					console.log('wait2 complete', Date.now() - start);
					resolve();
				}, 1000);
			});
		});

		browser.addCommand('wait3', function async() {
			return new Promise((resolve) => {
				console.log('wait3 starts', Date.now() - start);
				return this.wait1()
				.then(() => {
					console.log('wait3 middle', Date.now() - start);
				})
				.then(this.wait2)
				.then(() => {
					console.log('wait3 complete', Date.now() - start);
					resolve();
				});
			});
		});

		var start = Date.now();
		browser.wait3();
		console.log('wait3 after', (Date.now() - start));
```

This gives:
```
wait3 starts 1
wait1 complete 2
wait3 middle 2
wait3 complete 3
wait3 after 5
```