### PR TITLE
Only wrap a function in wdioSync a single time

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,8 +210,7 @@ let wrapCommands = function (instance, beforeCommand, afterCommand) {
          * #functionalProgrammingWTF!
          */
         commandGroup[fnName] = wrapCommand((...args) => new Promise((r) => {
-            fn = wdioSync(fn, r)
-            fn.apply(instance, args)
+            wdioSync(fn, r).apply(instance, args)
         }), fnName, beforeCommand, afterCommand)
     }
 }


### PR DESCRIPTION
Example:

```js
		browser.url('/');
		console.log('getConsoleErrors', browser.helpers.getConsoleErrors())
		console.log('getConsoleErrors', browser.helpers.getConsoleErrors())

// before fix:
// getConsoleErrors []
// getConsoleErrors undefined

// after fix:
// getConsoleErrors []
// getConsoleErrors []
```
