### PR TITLE
Assign wrapped command to namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ let wrapCommands = function (instance, beforeCommand, afterCommand) {
          * use bare promises to handle asynchronicity
          */
         if (fn.name === 'async') {
-            instance[fnName] = wrapCommand((...args) => {
+            commandGroup[fnName] = wrapCommand((...args) => {
                 forcePromises = true
                 let res = fn.apply(instance, args)
                 forcePromises = false


### PR DESCRIPTION
Example:

```js
		browser.addCommand('george', 'test', function async() {
			console.log('done');
		});

		browser.url('/');
		browser.george.test();

// before:
// TypeError: browser.george.test is not a function

// after:
// done
```