### PR TITLE
make commands chainable

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+    root: src

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ import Future from 'fibers/future'
 import Fiber from 'fibers'
 
 const SYNC_COMMANDS = ['domain', '_events', '_maxListeners', 'setMaxListeners', 'emit',
-    'addListener', 'on', 'once', 'removeListener', 'removeAllListeners', 'listeners']
+    'addListener', 'on', 'once', 'removeListener', 'removeAllListeners', 'listeners',
+    'getMaxListeners', 'listenerCount']
 
 let commandIsRunning = false
 let forcePromises = false
@@ -133,7 +134,7 @@ let wrapCommand = function (fn, commandName, beforeCommand, afterCommand) {
                 if (commandError) {
                     return future.throw(commandError)
                 }
-                return future.return(commandResult)
+                return future.return(applyPrototype(this, commandResult))
             })
 
         /**
@@ -149,6 +150,27 @@ let wrapCommand = function (fn, commandName, beforeCommand, afterCommand) {
             throw e
         }
     }
+}
+
+/**
+ * enhance result with instance prototype to enable command chaining
+ * @param  {Ibject} instance WebdriverIO instance
+ * @param  {[type]} result   command result
+ * @return {[type]}          command result with enhanced prototype
+ */
+let applyPrototype = function (instance, result) {
+    if (!result || typeof result !== 'object') {
+        return result
+    }
+
+    for (let commandName of Object.keys(Object.getPrototypeOf(instance))) {
+        if (result[commandName] || SYNC_COMMANDS.indexOf(commandName) > -1) {
+            continue
+        }
+        result[commandName] = instance[commandName].bind(instance)
+    }
+
+    return result
 }
 
 /**

--- a/test/wdio-sync.spec.js
+++ b/test/wdio-sync.spec.js
@@ -53,6 +53,14 @@ describe('wdio-sync', () => {
                 e.message.should.be.equal('buu')
             }
         })
+
+        after(() => {
+            /**
+             * reset globals
+             */
+            WDIOSyncRewire.__Rewire__('commandIsRunning', false)
+            WDIOSyncRewire.__Rewire__('forcePromises', false)
+        })
     })
 
     describe('wdioSync', () => {
@@ -78,6 +86,10 @@ describe('wdio-sync', () => {
                 done()
             }).bind(null, 'done'))
             process.nextTick(() => FiberMock.callArg(0))
+        })
+
+        after(() => {
+            WDIOSyncRewire.__ResetDependency__('Fiber')
         })
     })
 })

--- a/test/wrapCommand.spec.js
+++ b/test/wrapCommand.spec.js
@@ -1,0 +1,76 @@
+import { wrapCommands } from '../'
+import Fiber from 'fibers'
+
+const WebdriverIO = class {}
+WebdriverIO.prototype = {
+    getString: (a) => new Promise((r) => {
+        setTimeout(() => r('foo'), 50)
+    }),
+    getInteger: (ms = 50) => new Promise((r) => {
+        setTimeout(() => r(1), ms)
+    }),
+    getObject: (ms = 50) => new Promise((r) => {
+        setTimeout(() => r({}), ms)
+    }),
+    getUndefined: (ms = 50) => new Promise((r) => {
+        setTimeout(() => r(), ms)
+    }),
+    getNull: (ms = 50) => new Promise((r) => {
+        setTimeout(() => r(null), ms)
+    })
+}
+
+const NOOP = () => {}
+
+let instance
+
+let run = (fn) => {
+    return new Promise((resolve, reject) => {
+        try {
+            Fiber(() => {
+                fn()
+                resolve()
+            }).run()
+        } catch (e) {
+            reject(e)
+        }
+    })
+}
+
+describe('wrapCommand', () => {
+    before(() => {
+        instance = new WebdriverIO()
+        wrapCommands(instance, NOOP, NOOP)
+    })
+
+    it('should return actual results', () => {
+        return run(() => {
+            instance.getString().should.be.equal('foo')
+            instance.getInteger().should.be.equal(1)
+            let result = typeof instance.getUndefined()
+            result.should.be.equal('undefined')
+            result = instance.getNull() === null
+            result.should.be.true
+        })
+    })
+
+    it('should allow to chain objects', () => {
+        return run(() => {
+            instance.getObject().getInteger().should.be.equal(1)
+            instance.getObject().getString().should.be.equal('foo')
+        })
+    })
+
+    it('should not allow to chain strings, integer or falsy values', () => {
+        return run(() => {
+            let check = instance.getInteger().getObject === undefined
+            check.should.be.true
+            check = instance.getString().getObject === undefined
+            check.should.be.true
+            check = instance.getNull === null
+            check.should.be.true
+            check = instance.getUndefined === undefined
+            check.should.be.true
+        })
+    })
+})


### PR DESCRIPTION
Right now we can't chain commands anymore so we end up like this:
```js
browser.url("...");
browser.click(..);
browser.click(..);
browser.click(..);
var title = browser.getTitle()
```
This can be annoying and unfamiliar. This patch allows to chain commands again. Though it is limited to everything that returns an object (basically all protocol commands). It allows us to do this again:
```js
var title = browser
  .url("...")
  .click("...")
  .getTitle();
```