### PR TITLE
Run framework hooks in fiber context so they can call browser commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,14 @@ let runInFiberContext = function (testInterfaceFnName, before, after, fnName) {
         return origFn(function (done) {
             Fiber(() => {
                 executeHooksWithArgs(before)
-                    .then(() => hookFn.call(this))
+                    .then(() => {
+                        return new Promise(resolve => {
+                            return Fiber(() => {
+                                hookFn.call(this)
+                                resolve()
+                            }).run()
+                        })
+                    })
                     .then(() => executeHooksWithArgs(after))
                     .then(() => done(), () => done())
             }).run()


### PR DESCRIPTION
I'm not sure of the implications for this, but it fixed the issue for me.

```js
    beforeEach(function() {
        console.log('beforeEach starts')
        browser.url('/tests/www/')
        console.log('after browser.url', browser.url().value)
        console.log('beforeEach ends')
    });

    it('test', function() {
        console.log('test starting now')
        console.log('after browser.url', browser.url().value)
    });
```

before:
```
beforeEach starts
after browser.url { state: 'pending' }
beforeEach ends
test starting now
```

after: 
```
beforeEach starts
after browser.url http://127.0.0.1:9000/tests/www/
beforeEach ends
test starting now
```