### PR TITLE
co.wrap() spec and hook fns in async mode to keep compatibility with v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import Future from 'fibers/future'
 import Fiber from 'fibers'
 import assign from 'object.assign'
+import co from 'co'
 
 const SYNC_COMMANDS = ['domain', '_events', '_maxListeners', 'setMaxListeners', 'emit',
     'addListener', 'on', 'once', 'removeListener', 'removeAllListeners', 'listeners',
@@ -320,7 +321,7 @@ let runInFiberContext = function (testInterfaceFnNames, before, after, fnName) {
          * user wants handle async command using promises, no need to wrap in fiber context
          */
         if (isAsync()) {
-            return origFn.call(this, specTitle, specFn)
+            return origFn.call(this, specTitle, co.wrap(specFn))
         }
 
         return origFn(specTitle, function (done) {
@@ -340,7 +341,7 @@ let runInFiberContext = function (testInterfaceFnNames, before, after, fnName) {
                 executeHooksWithArgs(before).catch((e) => {
                     console.error(`Error in beforeHook: [${e}]`)
                 }).then(() => {
-                    return hookFn.call(this)
+                    return hookFn.call(co.wrap(this))
                 }).then(() => {
                     return executeHooksWithArgs(after)
                     .catch((e) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/webdriverio/wdio-sync#readme",
   "dependencies": {
     "babel": "^5.8.23",
+    "co": "^4.6.0",
     "fibers": "^1.0.9",
     "object.assign": "^4.0.3"
   },


### PR DESCRIPTION
`co.wrap()` spec and hook functions to keep backward compatibility with async control flow on `yield/generators` in v3. And for those who don't want to use babel to compile ES7 `async/await` in their tests suite.