### PR TITLE
Fix async tests in jasmine

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,9 +389,8 @@ let executeAsync = function (fn, repeatTest = 0, args = []) {
         if (error) {
             if (repeatTest) {
                 return executeAsync(fn, --repeatTest, args)
-            } else {
-                return new Promise((_, reject) => reject(result))
             }
+            return new Promise((_, reject) => reject(result))
         }
 
         /**
@@ -481,12 +480,12 @@ let runSpec = function (specTitle, specFn, origFn, repeatTest = 0) {
             return executeAsync.call(this, specFn, repeatTest)
                .then(() => done(), (e) => fail(e, done))
         })
-    } else {
-        return origFn(specTitle, function (resolve) {
-            let reject = typeof resolve.fail === 'function' ? resolve.fail : resolve
-            Fiber(() => executeSync.call(this, specFn, resolve, reject, repeatTest)).run()
-        })
     }
+
+    return origFn(specTitle, function (resolve) {
+        let reject = typeof resolve.fail === 'function' ? resolve.fail : resolve
+        Fiber(() => executeSync.call(this, specFn, resolve, reject, repeatTest)).run()
+    })
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -386,15 +386,19 @@ let executeAsync = function (fn, repeatTest = 0, args = []) {
          * handle errors that get thrown directly and are not cause by
          * rejected promises
          */
-        if (error && repeatTest) {
-            return executeAsync(fn, --repeatTest, args)
+        if (error) {
+            if (repeatTest) {
+                return executeAsync(fn, --repeatTest, args)
+            } else {
+                return new Promise((_, reject) => reject(result))
+            }
         }
 
         /**
          * if we don't retry just return result
          */
         if (repeatTest === 0 || !result || typeof result.catch !== 'function') {
-            return result
+            return new Promise(resolve => resolve(result))
         }
 
         /**
@@ -473,15 +477,16 @@ let runSpec = function (specTitle, specFn, origFn, repeatTest = 0) {
      * user wants handle async command using promises, no need to wrap in fiber context
      */
     if (isAsync() || specFn.name === 'async') {
-        return origFn(specTitle, function () {
+        return origFn(specTitle, function (done) {
             return executeAsync.call(this, specFn, repeatTest)
+               .then(() => done(), (e) => fail(e, done))
+        })
+    } else {
+        return origFn(specTitle, function (resolve) {
+            let reject = typeof resolve.fail === 'function' ? resolve.fail : resolve
+            Fiber(() => executeSync.call(this, specFn, resolve, reject, repeatTest)).run()
         })
     }
-
-    return origFn(specTitle, function (resolve) {
-        let reject = typeof resolve.fail === 'function' ? resolve.fail : resolve
-        Fiber(() => executeSync.call(this, specFn, resolve, reject, repeatTest)).run()
-    })
 }
 
 /**


### PR DESCRIPTION
This fixes https://github.com/webdriverio/wdio-jasmine-framework/issues/13 where jasmine test does not wait on promises returned by the `it` block.

The root cause is that jasmine determines if it should run a test in async or sync mode based on the number of arguments the function provided to `it` takes.  If the argument length is 0, then jasmine does not wait for the done to be called.  

This modifies runSpec to always run in jasmine async mode, wrapping non-promise results in promise that resolves immediately.  

Tested by using `npm link wdio-sync` into both `wdio-jasmine-framework ` and`wdio-mocha-framework` to ensure changes support both frameworks.  

Also tested with example project originally reproducing the issue here.  [webdriverio-async-jasmine-tests](https://github.com/kurtharriger/webdriverio-async-jasmine-tests)