### PR TITLE
Fix sanitizeErrorMessage corner case

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ let sanitizeErrorMessage = function (e) {
      * correct error occurence
      */
     let lineToFix = stack[stack.length - 1]
-    if (lineToFix.indexOf('index.js') > -1) {
+    if (lineToFix && lineToFix.indexOf('index.js') > -1) {
         stack[stack.length - 1] = lineToFix.slice(0, lineToFix.indexOf('index.js')) + errorLine
     } else {
         stack.unshift('    ' + errorLine)


### PR DESCRIPTION
(I believe this might be the cause of webdriverio/webdriverio#1726)

Scenario:

* a failing test throws an error
* the error gets caught and passed to `sanitizeErrorMessage` to fix its stack trace
* the error stack is only two-lines long, therefore the [`stack` array](https://github.com/webdriverio/wdio-sync/blob/master/index.js#L23) has length 2
* at least two elements are removed by the `stack` array (since it's `shift`-ed twice)
* the `stack` array is now empty, and [`lineToFix`](https://github.com/webdriverio/wdio-sync/blob/master/index.js#L42) is `undefined`, which causes a `TypeError: Cannot read property 'indexOf' of undefined`

(I can reproduce this in a client project I'm working on that I can't share, let me know if an "open reproduction" is needed)

The error is a bit erratic. On my local machine (macOS), with the exact same run, **sometimes it happens, sometimes it doesn't**, meaning **sometimes the stack trace has 2 lines, sometimes 3**. In a docker container (ubuntu) it appears to be systematic. I did not succeed to pinpoint the reason behind that.

This pull request attempts to fix the error described above by adding an undefined-check on `lineToFix`. Now when `lineToFix === undefined` the `else` case will be executed. I'm not sure if that is the correct/desired fallback though.