### PR TITLE
Don't crash when webdriverio.getAttribute returns an array of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,9 @@ let isElementsResult = function (result) {
 }
 
 let is$$Result = function (result) {
-    return Array.isArray(result) && result.length && result[0].ELEMENT !== undefined
+    // Commands like getAttribute can return an array of null when the attribute
+    // is not set.
+    return Array.isArray(result) && result.length && result[0] && result[0].ELEMENT !== undefined
 }
 
 /**

--- a/test/wrapCommand.spec.js
+++ b/test/wrapCommand.spec.js
@@ -18,6 +18,9 @@ WebdriverIO.prototype = {
     getNull: (ms = 50) => new Promise((r) => {
         setTimeout(() => r(null), ms)
     }),
+    getNulls: (ms = 50) => new Promise((r) => {
+        setTimeout(() => r([null, null]), ms)
+    }),
     waitUntilSync: (fn) => new Promise((r) => {
         return wdioSync(fn, r)()
     })
@@ -81,6 +84,12 @@ describe('wrapCommand', () => {
                 return instance.getObject()
             }).getString().should.be.equal('foo',
                 'waitUntil does not return enhanced prototype')
+        })
+    })
+
+    it('should not treat an array of null as a $$ result', () => {
+        return run(() => {
+            instance.getNulls().should.be.deepEqual([null, null])
         })
     })
 


### PR DESCRIPTION
Fixes #43.