### PR TITLE
Let runInFiberContext wrap non-global functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -629,20 +629,23 @@ let wrapTestFunction = function (fnName, origFn, testInterfaceFnNames, before, a
 
 /**
  * [runInFiberContext description]
- * @param  {[type]} testInterfaceFnNames  global command that runs specs
+ * @param  {[type]} testInterfaceFnNames  command that runs specs
  * @param  {[type]} before               before hook hook
  * @param  {[type]} after                after hook hook
  * @param  {[type]} fnName               test interface command to wrap
+ * @param  {[type]} scope                the scope to run command from, defaults to global
  */
-let runInFiberContext = function (testInterfaceFnNames, before, after, fnName) {
-    let origFn = global[fnName]
-    global[fnName] = wrapTestFunction(fnName, origFn, testInterfaceFnNames, before, after)
+// The scope parameter is used in the qunit framework since
+// all functions are bound to global.QUnit instead of global
+let runInFiberContext = function (testInterfaceFnNames, before, after, fnName, scope = global) {
+    let origFn = scope[fnName]
+    scope[fnName] = wrapTestFunction(fnName, origFn, testInterfaceFnNames, before, after)
 
     /**
      * support it.skip for the Mocha framework
      */
     if (typeof origFn.skip === 'function') {
-        global[fnName].skip = origFn.skip
+        scope[fnName].skip = origFn.skip
     }
 
     /**
@@ -650,7 +653,7 @@ let runInFiberContext = function (testInterfaceFnNames, before, after, fnName) {
      */
     if (typeof origFn.only === 'function') {
         let origOnlyFn = origFn.only
-        global[fnName].only = wrapTestFunction(fnName + '.only', origOnlyFn, testInterfaceFnNames, before, after)
+        scope[fnName].only = wrapTestFunction(fnName + '.only', origOnlyFn, testInterfaceFnNames, before, after)
     }
 }
 

--- a/test/wdio-sync.spec.js
+++ b/test/wdio-sync.spec.js
@@ -148,5 +148,24 @@ describe('wdio-sync', () => {
             }
             error.message.should.be.equal('buu')
         })
+
+        it('should replace original function in global scope', () => {
+            const origFakeBefore = global.fakeBefore
+            runInFiberContext(['it'], [], [], 'fakeBefore')
+            global.fakeBefore.should.not.equal(origFakeBefore)
+        })
+
+        it('should replace original function in custom scope', () => {
+            const scope = { fakeAfter: (cb) => cb() }
+
+            const origFakeBefore = global.fakeBefore
+            const origFakeAfter = scope.fakeAfter
+
+            runInFiberContext(['it'], [], [], 'fakeAfter', scope)
+
+            global.fakeBefore.should.equal(origFakeBefore)
+            global.should.not.have.property('fakeAfter')
+            scope.fakeAfter.should.not.equal(origFakeAfter)
+        })
     })
 })


### PR DESCRIPTION
Adds a `context` formal parameter that defaults to `global` to the method `runInFiberContext`.