### PR TITLE
fix: guard errorLine check from error stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ let sanitizeErrorMessage = function (e) {
     stack = stack.filter(STACKTRACE_FILTER_FN)
     stack = stack.map((e) => '    ' + e.replace(cwd + '/', '').trim())
 
-    /**
-     * this is just an assumption but works in most cases
-     */
-    let errorLine = stack.shift().trim()
+    let errorLine = 'unknown error line'
+    if (stack && stack.length) {
+        errorLine = stack.shift().trim()
+    }
 
     /**
      * correct error occurence


### PR DESCRIPTION
when the test execution is aborted and the application is not running, then the error stack can be empty

### Steps to re-produce

1. Configure the wdio config to use e.g. Safari, Chrome and Firefox
2. Do not launch your app
3. Abort the test execution
4. error is thrown, since there is no stack